### PR TITLE
Update chart_options.rb

### DIFF
--- a/lib/reports_kit/reports/data/chart_options.rb
+++ b/lib/reports_kit/reports/data/chart_options.rb
@@ -147,7 +147,7 @@ module ReportsKit
         end
 
         def donut_or_pie_chart?
-          type.in?(%w(donut pie))
+          type.in?(%w(doughnut pie))
         end
       end
     end


### PR DESCRIPTION
1.  When chart type 'doughnut' is supplied in yml config, chart has 'bar' chart formatting
2.  When 'donut' chart type is supplied in yml config no chart is displayed
Chart.js uses the the spelling 'doughnut' instead of 'donut' for the chart type...after change of 'donut' to 'doughnut' supplying chart type 'doughnut' in yml config... the chart formats as expected